### PR TITLE
Add operator interface notebook

### DIFF
--- a/Discretizing Linear Operators.ipynb
+++ b/Discretizing Linear Operators.ipynb
@@ -1,0 +1,421 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Overview\n",
+    "\n",
+    "This notebook includes prototypical code for the operator overview write-up. It does not depend on any exisiting code in DiffEqOperators, but it should be easy to modify the current codebase to achieve the same functionality.\n",
+    "\n",
+    "To make things simpler, everything is assumed to be time-invariant (so no `update_coefficients!`) and the datatype is `Float64`. I will also always use the out-of-place convention (i.e. `*` instead of `A_mul_B!`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import Base: +, *\n",
+    "\n",
+    "abstract type DiffEqOperator end\n",
+    "abstract type DiffEqLinearOperator <: DiffEqOperator end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 1. Abstract Operator Interface\n",
+    "\n",
+    "Below is a simplified operator interface used in my new interface draft. Basically we want to express lazy addition and multiplication of linear operators naturally using `+` and `*`. The `as_array` interface returns the most suitable (dense/sparse) representation of the underlying operator as an `AbstractMatrix` (or should we treat this as a type conversion and just use `AbstractMatrix`?).\n",
+    "\n",
+    "The affine operator is defined in such a way that arithmetic on them and linear operators always yield an `DiffEqAffineOperator`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "struct DiffEqArrayOperator <: DiffEqLinearOperator\n",
+    "    A::AbstractMatrix{Float64}\n",
+    "end\n",
+    "\n",
+    "*(L::DiffEqArrayOperator, x::Vector{Float64}) = L.A * x\n",
+    "as_array(L::DiffEqArrayOperator) = L.A\n",
+    "\n",
+    "struct DiffEqOperatorCombination <: DiffEqLinearOperator\n",
+    "    ops::Tuple{Vararg{DiffEqLinearOperator}}\n",
+    "end\n",
+    "\n",
+    "*(L::DiffEqOperatorCombination, x::Vector{Float64}) = sum(op -> op*x, L.ops)\n",
+    "as_array(L::DiffEqOperatorCombination) = sum(as_array, L.ops)\n",
+    "\n",
+    "struct DiffEqOperatorComposition <: DiffEqLinearOperator\n",
+    "    ops::Tuple{Vararg{DiffEqLinearOperator}}\n",
+    "end\n",
+    "\n",
+    "*(L::DiffEqOperatorComposition, x::Vector{Float64}) = foldl((u, op) -> op*u, x, L.ops)\n",
+    "as_array(L::DiffEqOperatorComposition) = prod(as_array, reverse(L.ops))\n",
+    "\n",
+    "# Arithmetic\n",
+    "# op + op\n",
+    "+(L1::DiffEqOperatorCombination, L2::DiffEqOperatorCombination) = DiffEqOperatorCombination((L1.ops..., L2.ops...))\n",
+    "+(L1::DiffEqOperatorCombination, L2::DiffEqLinearOperator) = DiffEqOperatorCombination((L1.ops..., L2))\n",
+    "+(L1::DiffEqLinearOperator, L2::DiffEqOperatorCombination) = DiffEqOperatorCombination((L1, L2.ops...))\n",
+    "+(L1::DiffEqLinearOperator, L2::DiffEqLinearOperator) = DiffEqOperatorCombination((L1,L2))\n",
+    "\n",
+    "# op * op\n",
+    "# Note the application order\n",
+    "*(L1::DiffEqOperatorComposition, L2::DiffEqOperatorComposition) = DiffEqOperatorComposition((L2.ops..., L1.ops...))\n",
+    "*(L1::DiffEqLinearOperator, L2::DiffEqOperatorComposition) = DiffEqOperatorComposition((L2.ops..., L1))\n",
+    "*(L1::DiffEqOperatorComposition, L2::DiffEqLinearOperator) = DiffEqOperatorComposition((L2, L1.ops...))\n",
+    "*(L1::DiffEqLinearOperator, L2::DiffEqLinearOperator) = DiffEqOperatorComposition((L2, L1));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Affine Operator\n",
+    "struct DiffEqAffineOperator <: DiffEqOperator\n",
+    "    A::DiffEqOperator\n",
+    "    b::Vector{Float64}\n",
+    "end\n",
+    "\n",
+    "*(L::DiffEqAffineOperator, x::Vector{Float64}) = L.A * x + L.b\n",
+    "\n",
+    "# Arithmetic on affine operators\n",
+    "+(L1::DiffEqLinearOperator, L2::DiffEqAffineOperator) = DiffEqAffineOperator(L1 + L2.A, L2.b)\n",
+    "+(L1::DiffEqAffineOperator, L2::DiffEqLinearOperator) = DiffEqAffineOperator(L1.A + L2, L1.b)\n",
+    "+(L1::DiffEqAffineOperator, L2::DiffEqAffineOperator) = DiffEqAffineOperator(L1.A + L2.A, L1.b + L2.b)\n",
+    "*(L1::DiffEqLinearOperator, L2::DiffEqAffineOperator) = DiffEqAffineOperator(L1 * L2.A, L1 * L2.b)\n",
+    "*(L1::DiffEqAffineOperator, L2::DiffEqLinearOperator) = DiffEqAffineOperator(L1.A * L2, L1.b)\n",
+    "*(L1::DiffEqAffineOperator, L2::DiffEqAffineOperator) = DiffEqAffineOperator(L1.A * L2.A, L1.A * L2.b + L1.b);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 2. Operators on the interior (stencil convolution)\n",
+    "\n",
+    "The 2nd-order central difference approximation to $\\partial_x^2/2$ and the 1st-order upwind approximation to $\\partial_x$ are included. The general case can be modified from the stencil convolution code in DiffEqOperators.\n",
+    "\n",
+    "The upwind operator is implemented differently from DiffEqOperators, where the direction at each point is stored. Here only the left/right operator is constructed and we interpret\n",
+    "\n",
+    "$$ \\mu(x)\\partial_x = \\mu^+(x)\\partial_x^+ + \\mu^-(x)\\partial_x^- $$\n",
+    "\n",
+    "This is the approach used in the write-up. Though maybe not as efficient, this is clearer both conceptually and from a coding standpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "struct DiffusionOperator <: DiffEqLinearOperator\n",
+    "    dx::Float64\n",
+    "    m::Int # number of interior points\n",
+    "end\n",
+    "\n",
+    "*(L::DiffusionOperator, x::Vector{Float64}) = [x[i] + x[i+2] - 2*x[i+1] for i in 1:L.m] / L.dx^2\n",
+    "as_array(L::DiffusionOperator) = spdiagm((ones(L.m), -2*ones(L.m), ones(L.m)), (0,1,2)) / L.dx^2;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "struct DriftOperator <: DiffEqLinearOperator\n",
+    "    dx::Float64\n",
+    "    m::Int # number of interior points\n",
+    "    direction::Bool # true = right, false = left\n",
+    "end\n",
+    "\n",
+    "function *(L::DriftOperator, x::Vector{Float64})\n",
+    "    if L.direction # right drift\n",
+    "        [x[i+1] - x[i] for i in 1:L.m] / L.dx\n",
+    "    else # left drift\n",
+    "        [x[i+2] - x[i+1] for i in 1:L.m] / L.dx\n",
+    "    end\n",
+    "end\n",
+    "function as_array(L::DriftOperator)\n",
+    "    if L.direction # right drift\n",
+    "        spdiagm((-ones(L.m), ones(L.m), zeros(L.m)), (0,1,2)) / L.dx\n",
+    "    else # left drift\n",
+    "        spdiagm((zeros(L.m), -ones(L.m), ones(L.m)), (0,1,2)) / L.dx\n",
+    "    end\n",
+    "end;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 3. Boundary Maps (The $Q$ Operator)\n",
+    "\n",
+    "(I'm calling the $Q$ operators the \"boundary maps\" temporarily, but I guess a better name should be used?)\n",
+    "\n",
+    "A generic $Q$ from the generic boundary condition $Bu = b$ can be a bit difficult to implement, but the simple case of Dirichlet/Neumann BC is easy to handle.\n",
+    "\n",
+    "It should be easy to modify `AbsorbingBoundaryMap` and `ReflectingBoundaryMap` to incorporate boundaries that are absorbing at one end and reflecting at another.\n",
+    "\n",
+    "The non-zero Dirichlet/Neumann boundary maps do not have their own type. Instead we construct the `Q` operator as an affine map, with `AbsorbingBoundaryMap` and `ReflectingBoundaryMap` its linear part."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "struct AbsorbingBoundaryMap <: DiffEqLinearOperator\n",
+    "    m::Int # number of interior points\n",
+    "end\n",
+    "\n",
+    "*(Q::AbsorbingBoundaryMap, x::Vector{Float64}) = [0.0; x; 0.0]\n",
+    "as_array(Q::AbsorbingBoundaryMap) = sparse([zeros(Q.m)'; eye(Q.m); zeros(Q.m)'])\n",
+    "\n",
+    "struct ReflectingBoundaryMap <: DiffEqLinearOperator\n",
+    "    m::Int # number of interior points\n",
+    "end\n",
+    "\n",
+    "*(Q::ReflectingBoundaryMap, x::Vector{Float64}) = [x[1]; x; x[end]]\n",
+    "as_array(Q::ReflectingBoundaryMap) = sparse([1.0 zeros(Q.m-1)'; eye(Q.m); zeros(Q.m-1)' 1.0]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "function Dirichlet_boundary_map(m::Int, bl::Float64, br::Float64)\n",
+    "    # y[1] = bl, y[end] = br\n",
+    "    Qa = AbsorbingBoundaryMap(m)\n",
+    "    Qb = [bl; zeros(m); br]\n",
+    "    DiffEqAffineOperator(Qa, Qb)\n",
+    "end\n",
+    "\n",
+    "function Neumann_boundary_map(m::Int, dx::Float64, bl::Float64, br::Float64)\n",
+    "    # (y[2] - y[1])/dx = bl, (y[end] - y[end-1])/dx = br\n",
+    "    Qa = ReflectingBoundaryMap(m)\n",
+    "    Qb = [-bl*dx; zeros(m); br*dx]\n",
+    "    DiffEqAffineOperator(Qa, Qb)\n",
+    "end;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Examples of non-zero BC:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "dx = 1.0\n",
+    "u = [1.,2.,3.,4.]\n",
+    "QD = Dirichlet_boundary_map(4, 10.0, 20.0)\n",
+    "QN = Neumann_boundary_map(4, dx, 1.0, 2.0);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6-element Array{Float64,1}:\n",
+       " 10.0\n",
+       "  1.0\n",
+       "  2.0\n",
+       "  3.0\n",
+       "  4.0\n",
+       " 20.0"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "QD * u"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6-element Array{Float64,1}:\n",
+       " 0.0\n",
+       " 1.0\n",
+       " 2.0\n",
+       " 3.0\n",
+       " 4.0\n",
+       " 6.0"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "QN * u"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 4. Constructing operators for the Fokker-Planck equations\n",
+    "\n",
+    "The most general case is in section 3.5 of the write-up:\n",
+    "\n",
+    "$$ \\mathcal{L} = \\mu(x)\\partial_x + \\frac{\\sigma(x)^2}{2}\\partial_{xx} $$\n",
+    "\n",
+    "where the drift term is discretized using upwind operators as described in section 2:\n",
+    "\n",
+    "$$ \\mu(x)\\partial_x = \\mu^+(x)\\partial_x^+ + \\mu^-(x)\\partial_x^- $$\n",
+    "\n",
+    "The discretized operators are expressed as the composition of an interior stencil convolution operator `A` and boundary map `Q` (they are generally affine). The drift and diffusion coefficients can be expressed as diagonal matrices (wrapped in a `DiffEqArrayOperator`).\n",
+    "\n",
+    "The script below can be modified to represent each of the scenarios described in secition 3 of the write-up (except the mixed-BC case)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DiffEqOperatorComposition((AbsorbingBoundaryMap(10), DiffEqOperatorCombination((DiffEqOperatorComposition((DriftOperator(1.0, 10, true), DiffEqArrayOperator([0.123526 0.0 … 0.0 0.0; 0.0 0.77393 … 0.0 0.0; … ; 0.0 0.0 … 0.672812 0.0; 0.0 0.0 … 0.0 0.751455]))), DiffEqOperatorComposition((DriftOperator(1.0, 10, false), DiffEqArrayOperator([0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]))), DiffEqOperatorComposition((DiffusionOperator(1.0, 10), DiffEqArrayOperator([1.32813 0.0 … 0.0 0.0; 0.0 0.59207 … 0.0 0.0; … ; 0.0 0.0 … 1.87849 0.0; 0.0 0.0 … 0.0 1.22985])))))))"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The grid\n",
+    "N = 10\n",
+    "dx = 1.0\n",
+    "xs = collect(1:N) * dx # interior nodes\n",
+    "\n",
+    "# Interior operators\n",
+    "A1p = DriftOperator(dx, N, true)\n",
+    "A1m = DriftOperator(dx, N, false)\n",
+    "A2 = DiffusionOperator(dx, N)\n",
+    "\n",
+    "# Boundary operators\n",
+    "Q = AbsorbingBoundaryMap(N)\n",
+    "# Q = Neumann_boundary_map(N, dx, 1.0, 2.0)\n",
+    "\n",
+    "# Coefficients\n",
+    "mu = rand(N)\n",
+    "mup = [mu[i] > 0.0 ? mu[i] : 0.0 for i in 1:N]\n",
+    "mum = [mu[i] < 0.0 ? mu[i] : 0.0 for i in 1:N]\n",
+    "sigma = rand(N) + 1.0\n",
+    "\n",
+    "# Construct L\n",
+    "L1 = DiffEqArrayOperator(Diagonal(mup)) * A1p + DiffEqArrayOperator(Diagonal(mum)) * A1m\n",
+    "L2 = DiffEqArrayOperator(Diagonal(sigma.^2 / 2)) * A2\n",
+    "L = (L1 + L2) * Q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(The standard printout for the composed operator is a bit messy. Should probably implement `Base.show` for the composition types)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10-element Array{Float64,1}:\n",
+       " 32.1917\n",
+       " 61.8482\n",
+       " 54.584 \n",
+       " 47.3014\n",
+       " 46.0182\n",
+       " 43.7368\n",
+       " 38.5641\n",
+       " 31.9659\n",
+       " 22.1972\n",
+       " 11.7271"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Solve the HJBE (rI - L)u = x\n",
+    "r = 0.05\n",
+    "if isa(L, DiffEqAffineOperator)\n",
+    "    LHS = r*speye(N) - as_array(L.A)\n",
+    "    RHS = xs + L.b\n",
+    "else\n",
+    "    LHS = r*speye(N) - as_array(L)\n",
+    "    RHS = xs\n",
+    "end\n",
+    "u = LHS \\ RHS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 0.6.2",
+   "language": "julia",
+   "name": "julia-0.6"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "0.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Prototype notebook for the operator overview document ([nbviewer](https://nbviewer.jupyter.org/github/MSeeker1340/PDERoadmap/blob/operator_interface_prototype/Discretizing%20Linear%20Operators.ipynb)). Most of the abstract type hierarchy is taken from my previous notebook (simplified for the sake of brevity). Not so sure about some aspects of the notebook so I could use your suggestions:

1. The affine operator interface. Do you think having operations on affine operators always return a `DiffEqAffineOperator` is a good idea?

2. The `Q` operators. In particular, having dedicated "basic" operators for simple BC (`AbsorbingBoundaryMap` and `ReflectingBoundaryMap`) and build complex BC from the basic ones.

    2.1. Also, what should the `Q` operators be called?

3. The drift operators. The way it is done in the notebook (separate right/left going upwind operator) is different from what is currently implemented in DiffEqOperators (a single operator with an embedded `directions` vector). Performance-wise the latter is probably better (half the amount of work) but the code might get complicated if we start doing time-dependent coefficients.

4. The coefficients: currently they are implemented just as `Diagonal` matrices. Another approach would be to embed the coefficients inside the operators.

By the way, the last section is just meant to check the interface itself. Can anyone suggest some concrete examples that I can check to make sure the implementation is correct numerically?