### PR TITLE
Operator interface prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _minted*
 *.fdb_latexmk
 *.bbl
 *.blg
+.ipynb_checkpoints/

--- a/Discretizing Linear Operators.ipynb
+++ b/Discretizing Linear Operators.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "- `L` denotes a (quasi)linear operator.\n",
     "\n",
-    "- `A` denotes an operator that can generally be affine.\n",
+    "- `A` denotes an operator that can generally (but not necessarily) be affine.\n",
     "\n",
     "- `b` denotes the bias of an affine operator\n",
     "\n",
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import Base: +, *\n",
+    "import Base: +, -, *, \\\n",
     "\n",
     "abstract type DiffEqOperator end\n",
     "abstract type DiffEqLinearOperator <: DiffEqOperator end"
@@ -62,11 +62,12 @@
     "as_array(L::DiffEqArrayOperator) = L.M\n",
     "\n",
     "struct DiffEqOperatorCombination <: DiffEqLinearOperator\n",
+    "    cs::Tuple{Vararg{Float64}} # Coefficients\n",
     "    Ls::Tuple{Vararg{DiffEqLinearOperator}}\n",
     "end\n",
     "\n",
-    "*(L::DiffEqOperatorCombination, x::Vector{Float64}) = sum(Lk -> Lk*x, L.Ls)\n",
-    "as_array(L::DiffEqOperatorCombination) = sum(as_array, L.Ls)\n",
+    "*(L::DiffEqOperatorCombination, x::Vector{Float64}) = sum(ck * (Lk*x) for (ck,Lk) in zip(L.cs,L.Ls))\n",
+    "as_array(L::DiffEqOperatorCombination) = sum(ck * as_array(Lk) for (ck,Lk) in zip(L.cs,L.Ls))\n",
     "\n",
     "struct DiffEqOperatorComposition <: DiffEqLinearOperator\n",
     "    Ls::Tuple{Vararg{DiffEqLinearOperator}}\n",
@@ -75,21 +76,12 @@
     "*(L::DiffEqOperatorComposition, x::Vector{Float64}) = foldl((u, Lk) -> Lk*u, x, L.Ls)\n",
     "as_array(L::DiffEqOperatorComposition) = prod(as_array, reverse(L.Ls))\n",
     "\n",
-    "# Arithmetic\n",
-    "# L1 + L2\n",
-    "+(L1::DiffEqOperatorCombination, L2::DiffEqOperatorCombination) = DiffEqOperatorCombination((L1.Ls..., L2.Ls...))\n",
-    "+(L1::DiffEqOperatorCombination, L2::DiffEqLinearOperator) = DiffEqOperatorCombination((L1.Ls..., L2))\n",
-    "+(L1::DiffEqLinearOperator, L2::DiffEqOperatorCombination) = DiffEqOperatorCombination((L1, L2.Ls...))\n",
-    "+(L1::DiffEqLinearOperator, L2::DiffEqLinearOperator) = DiffEqOperatorCombination((L1, L2))\n",
+    "struct DiffEqAffineOperator <: DiffEqOperator\n",
+    "    L::DiffEqLinearOperator\n",
+    "    b::Vector{Float64}\n",
+    "end\n",
     "\n",
-    "# We can implement '-' after adding in coefficients for the combinations\n",
-    "\n",
-    "# L1 * L2\n",
-    "# Note the application order\n",
-    "*(L1::DiffEqOperatorComposition, L2::DiffEqOperatorComposition) = DiffEqOperatorComposition((L2.Ls..., L1.Ls...))\n",
-    "*(L1::DiffEqLinearOperator, L2::DiffEqOperatorComposition) = DiffEqOperatorComposition((L2.Ls..., L1))\n",
-    "*(L1::DiffEqOperatorComposition, L2::DiffEqLinearOperator) = DiffEqOperatorComposition((L2, L1.Ls...))\n",
-    "*(L1::DiffEqLinearOperator, L2::DiffEqLinearOperator) = DiffEqOperatorComposition((L2, L1));"
+    "*(A::DiffEqAffineOperator, x::Vector{Float64}) = A.L * x + A.b;"
    ]
   },
   {
@@ -98,21 +90,43 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Affine Operator\n",
-    "struct DiffEqAffineOperator <: DiffEqOperator\n",
-    "    L::DiffEqLinearOperator\n",
-    "    b::Vector{Float64}\n",
-    "end\n",
+    "# Operator arithmetic\n",
+    "# Addition\n",
+    "+(L1::DiffEqOperatorCombination, L2::DiffEqOperatorCombination) = DiffEqOperatorCombination(\n",
+    "    (L1.cs...,L2.cs...), (L1.Ls...,L2.Ls...))\n",
+    "+(L1::DiffEqOperatorCombination, L2::DiffEqLinearOperator) = DiffEqOperatorCombination((L1.cs...,1.0), (L1.Ls...,L2))\n",
+    "+(L1::DiffEqLinearOperator, L2::DiffEqOperatorCombination) = L2 + L1\n",
+    "+(L1::DiffEqLinearOperator, L2::DiffEqLinearOperator) = DiffEqOperatorCombination((1.0,1.0), (L1,L2))\n",
     "\n",
-    "*(A::DiffEqAffineOperator, x::Vector{Float64}) = A.L * x + A.b\n",
-    "\n",
-    "# Arithmetic on affine operators\n",
-    "+(L1::DiffEqLinearOperator, A2::DiffEqAffineOperator) = DiffEqAffineOperator(L1 + A2.L, A2.b)\n",
     "+(A1::DiffEqAffineOperator, L2::DiffEqLinearOperator) = DiffEqAffineOperator(A1.L + L2, A1.b)\n",
+    "+(L1::DiffEqLinearOperator, A2::DiffEqAffineOperator) = A2 + L1\n",
     "+(A1::DiffEqAffineOperator, A2::DiffEqAffineOperator) = DiffEqAffineOperator(A1.L + A2.L, A1.b + A2.b)\n",
+    "\n",
+    "# Scalar multiplication\n",
+    "*(α::Float64, L::DiffEqOperatorCombination) = DiffEqOperatorCombination(α.*L.cs, L.Ls)\n",
+    "*(α::Float64, L::DiffEqLinearOperator) = DiffEqOperatorCombination((α,), (L,))\n",
+    "*(α::Float64, A::DiffEqAffineOperator) = DiffEqAffineOperator(α * A.L, α * A.b)\n",
+    "*(A::DiffEqOperator, α::Float64) = α * A\n",
+    "\n",
+    "# Subtraction/unary minus\n",
+    "-(A::DiffEqOperator) = (-1.0) * A\n",
+    "-(A1::DiffEqOperator, A2::DiffEqOperator) = A1 + (-A2)\n",
+    "\n",
+    "# Multiplication\n",
+    "# Note the application order\n",
+    "*(L1::DiffEqOperatorComposition, L2::DiffEqOperatorComposition) = DiffEqOperatorComposition((L2.Ls..., L1.Ls...))\n",
+    "*(L1::DiffEqLinearOperator, L2::DiffEqOperatorComposition) = DiffEqOperatorComposition((L2.Ls..., L1))\n",
+    "*(L1::DiffEqOperatorComposition, L2::DiffEqLinearOperator) = DiffEqOperatorComposition((L2, L1.Ls...))\n",
+    "*(L1::DiffEqLinearOperator, L2::DiffEqLinearOperator) = DiffEqOperatorComposition((L2, L1))\n",
+    "\n",
     "*(L1::DiffEqLinearOperator, A2::DiffEqAffineOperator) = DiffEqAffineOperator(L1 * A2.L, L1 * A2.b)\n",
     "*(A1::DiffEqAffineOperator, L2::DiffEqLinearOperator) = DiffEqAffineOperator(A1.L * L2, A1.b)\n",
-    "*(A1::DiffEqAffineOperator, A2::DiffEqAffineOperator) = DiffEqAffineOperator(A1.L * A2.L, A1.L * A2.b + A1.b);"
+    "*(A1::DiffEqAffineOperator, A2::DiffEqAffineOperator) = DiffEqAffineOperator(A1.L * A2.L, A1.L * A2.b + A1.b)\n",
+    "\n",
+    "# Right division (i.e. linear solve)\n",
+    "# In the full version we should also include interface to lazy solvers\n",
+    "\\(L::DiffEqLinearOperator, y::Vector{Float64}) = as_array(L) \\ y\n",
+    "\\(A::DiffEqAffineOperator, y::Vector{Float64}) = A.L \\ (y - A.b);"
    ]
   },
   {
@@ -330,7 +344,7 @@
     {
      "data": {
       "text/plain": [
-       "DiffEqOperatorComposition((AbsorbingBE(10), DiffEqOperatorCombination((DiffEqOperatorComposition((DriftOperator(1.0, 10, true), DiffEqArrayOperator([0.282496 0.0 … 0.0 0.0; 0.0 0.840896 … 0.0 0.0; … ; 0.0 0.0 … 0.518511 0.0; 0.0 0.0 … 0.0 0.896779]))), DiffEqOperatorComposition((DriftOperator(1.0, 10, false), DiffEqArrayOperator([0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]))), DiffEqOperatorComposition((DiffusionOperator(1.0, 10), DiffEqArrayOperator([1.76829 0.0 … 0.0 0.0; 0.0 1.59721 … 0.0 0.0; … ; 0.0 0.0 … 0.676772 0.0; 0.0 0.0 … 0.0 1.25609])))))))"
+       "DiffEqOperatorComposition((AbsorbingBE(10), DiffEqOperatorCombination((1.0, 1.0, 1.0), (DiffEqOperatorComposition((DriftOperator(1.0, 10, true), DiffEqArrayOperator([0.887661 0.0 … 0.0 0.0; 0.0 0.213112 … 0.0 0.0; … ; 0.0 0.0 … 0.436606 0.0; 0.0 0.0 … 0.0 0.569388]))), DiffEqOperatorComposition((DriftOperator(1.0, 10, false), DiffEqArrayOperator([0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]))), DiffEqOperatorComposition((DiffusionOperator(1.0, 10), DiffEqArrayOperator([1.89194 0.0 … 0.0 0.0; 0.0 0.597414 … 0.0 0.0; … ; 0.0 0.0 … 0.539805 0.0; 0.0 0.0 … 0.0 0.94818])))))))"
       ]
      },
      "execution_count": 11,
@@ -381,16 +395,16 @@
      "data": {
       "text/plain": [
        "10-element Array{Float64,1}:\n",
-       " 19.0086\n",
-       " 34.9524\n",
-       " 42.3442\n",
-       " 45.8283\n",
-       " 46.1967\n",
-       " 44.579 \n",
-       " 38.5766\n",
-       " 32.2452\n",
-       " 24.5824\n",
-       " 11.3082"
+       " 24.4109\n",
+       " 37.4853\n",
+       " 45.6853\n",
+       " 52.2336\n",
+       " 51.9707\n",
+       " 50.2344\n",
+       " 46.5129\n",
+       " 37.9023\n",
+       " 30.9117\n",
+       " 15.7658"
       ]
      },
      "execution_count": 12,
@@ -400,17 +414,9 @@
    ],
    "source": [
     "# Solve the HJBE (rI - A)u = x\n",
-    "# In the complete version, we can just do (r*I - A) \\ u\n",
-    "# For now we will break the access barrier and get dirty\n",
     "r = 0.05\n",
-    "if isa(A, DiffEqAffineOperator)\n",
-    "    LHS = r*speye(N) - as_array(A.L)\n",
-    "    RHS = xs + A.b\n",
-    "else\n",
-    "    LHS = r*speye(N) - as_array(A)\n",
-    "    RHS = xs\n",
-    "end\n",
-    "u = LHS \\ RHS"
+    "LHS = DiffEqArrayOperator(r*speye(N)) - A\n",
+    "u = LHS \\ xs"
    ]
   },
   {

--- a/Discretizing Linear Operators.ipynb
+++ b/Discretizing Linear Operators.ipynb
@@ -8,7 +8,17 @@
     "\n",
     "This notebook includes prototypical code for the operator overview write-up. It does not depend on any exisiting code in DiffEqOperators, but it should be easy to modify the current codebase to achieve the same functionality.\n",
     "\n",
-    "To make things simpler, everything is assumed to be time-invariant (so no `update_coefficients!`) and the datatype is `Float64`. I will also always use the out-of-place convention (i.e. `*` instead of `A_mul_B!`)."
+    "To make things simpler, everything is assumed to use `Float64` datatype. I will also always use the out-of-place convention (i.e. `*` instead of `A_mul_B!`).\n",
+    "\n",
+    "The naming of different operators will use the following convention, as in the writeup:\n",
+    "\n",
+    "- `L` denotes a (quasi)linear operator.\n",
+    "\n",
+    "- `A` denotes an operator that can generally be affine.\n",
+    "\n",
+    "- `b` denotes the bias of an affine operator\n",
+    "\n",
+    "- (Not discussed but I guess we may as well make the call?) `M` for raw matrices (`AbstractMatrix`) and `x`, `y`, `u`, etc for vectors."
    ]
   },
   {
@@ -27,7 +37,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 1. Abstract Operator Interface\n",
+    "# 1. Constant case (i.e. no `update_coefficients!`)\n",
+    "\n",
+    "## 1.1 Abstract operator interface\n",
     "\n",
     "Below is a simplified operator interface used in my new interface draft. Basically we want to express lazy addition and multiplication of linear operators naturally using `+` and `*`. The `as_array` interface returns the most suitable (dense/sparse) representation of the underlying operator as an `AbstractMatrix` (or should we treat this as a type conversion and just use `AbstractMatrix`?).\n",
     "\n",
@@ -40,39 +52,43 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# We should improve type stability by including more inferrable fields in the type signature\n",
+    "# But for the sake of this notebook I'll make things simple\n",
     "struct DiffEqArrayOperator <: DiffEqLinearOperator\n",
-    "    A::AbstractMatrix{Float64}\n",
+    "    M::AbstractMatrix{Float64}\n",
     "end\n",
     "\n",
-    "*(L::DiffEqArrayOperator, x::Vector{Float64}) = L.A * x\n",
-    "as_array(L::DiffEqArrayOperator) = L.A\n",
+    "*(L::DiffEqArrayOperator, x::Vector{Float64}) = L.M * x\n",
+    "as_array(L::DiffEqArrayOperator) = L.M\n",
     "\n",
     "struct DiffEqOperatorCombination <: DiffEqLinearOperator\n",
-    "    ops::Tuple{Vararg{DiffEqLinearOperator}}\n",
+    "    Ls::Tuple{Vararg{DiffEqLinearOperator}}\n",
     "end\n",
     "\n",
-    "*(L::DiffEqOperatorCombination, x::Vector{Float64}) = sum(op -> op*x, L.ops)\n",
-    "as_array(L::DiffEqOperatorCombination) = sum(as_array, L.ops)\n",
+    "*(L::DiffEqOperatorCombination, x::Vector{Float64}) = sum(Lk -> Lk*x, L.Ls)\n",
+    "as_array(L::DiffEqOperatorCombination) = sum(as_array, L.Ls)\n",
     "\n",
     "struct DiffEqOperatorComposition <: DiffEqLinearOperator\n",
-    "    ops::Tuple{Vararg{DiffEqLinearOperator}}\n",
+    "    Ls::Tuple{Vararg{DiffEqLinearOperator}}\n",
     "end\n",
     "\n",
-    "*(L::DiffEqOperatorComposition, x::Vector{Float64}) = foldl((u, op) -> op*u, x, L.ops)\n",
-    "as_array(L::DiffEqOperatorComposition) = prod(as_array, reverse(L.ops))\n",
+    "*(L::DiffEqOperatorComposition, x::Vector{Float64}) = foldl((u, Lk) -> Lk*u, x, L.Ls)\n",
+    "as_array(L::DiffEqOperatorComposition) = prod(as_array, reverse(L.Ls))\n",
     "\n",
     "# Arithmetic\n",
-    "# op + op\n",
-    "+(L1::DiffEqOperatorCombination, L2::DiffEqOperatorCombination) = DiffEqOperatorCombination((L1.ops..., L2.ops...))\n",
-    "+(L1::DiffEqOperatorCombination, L2::DiffEqLinearOperator) = DiffEqOperatorCombination((L1.ops..., L2))\n",
-    "+(L1::DiffEqLinearOperator, L2::DiffEqOperatorCombination) = DiffEqOperatorCombination((L1, L2.ops...))\n",
-    "+(L1::DiffEqLinearOperator, L2::DiffEqLinearOperator) = DiffEqOperatorCombination((L1,L2))\n",
+    "# L1 + L2\n",
+    "+(L1::DiffEqOperatorCombination, L2::DiffEqOperatorCombination) = DiffEqOperatorCombination((L1.Ls..., L2.Ls...))\n",
+    "+(L1::DiffEqOperatorCombination, L2::DiffEqLinearOperator) = DiffEqOperatorCombination((L1.Ls..., L2))\n",
+    "+(L1::DiffEqLinearOperator, L2::DiffEqOperatorCombination) = DiffEqOperatorCombination((L1, L2.Ls...))\n",
+    "+(L1::DiffEqLinearOperator, L2::DiffEqLinearOperator) = DiffEqOperatorCombination((L1, L2))\n",
     "\n",
-    "# op * op\n",
+    "# We can implement '-' after adding in coefficients for the combinations\n",
+    "\n",
+    "# L1 * L2\n",
     "# Note the application order\n",
-    "*(L1::DiffEqOperatorComposition, L2::DiffEqOperatorComposition) = DiffEqOperatorComposition((L2.ops..., L1.ops...))\n",
-    "*(L1::DiffEqLinearOperator, L2::DiffEqOperatorComposition) = DiffEqOperatorComposition((L2.ops..., L1))\n",
-    "*(L1::DiffEqOperatorComposition, L2::DiffEqLinearOperator) = DiffEqOperatorComposition((L2, L1.ops...))\n",
+    "*(L1::DiffEqOperatorComposition, L2::DiffEqOperatorComposition) = DiffEqOperatorComposition((L2.Ls..., L1.Ls...))\n",
+    "*(L1::DiffEqLinearOperator, L2::DiffEqOperatorComposition) = DiffEqOperatorComposition((L2.Ls..., L1))\n",
+    "*(L1::DiffEqOperatorComposition, L2::DiffEqLinearOperator) = DiffEqOperatorComposition((L2, L1.Ls...))\n",
     "*(L1::DiffEqLinearOperator, L2::DiffEqLinearOperator) = DiffEqOperatorComposition((L2, L1));"
    ]
   },
@@ -84,34 +100,34 @@
    "source": [
     "# Affine Operator\n",
     "struct DiffEqAffineOperator <: DiffEqOperator\n",
-    "    A::DiffEqOperator\n",
+    "    L::DiffEqLinearOperator\n",
     "    b::Vector{Float64}\n",
     "end\n",
     "\n",
-    "*(L::DiffEqAffineOperator, x::Vector{Float64}) = L.A * x + L.b\n",
+    "*(A::DiffEqAffineOperator, x::Vector{Float64}) = A.L * x + A.b\n",
     "\n",
     "# Arithmetic on affine operators\n",
-    "+(L1::DiffEqLinearOperator, L2::DiffEqAffineOperator) = DiffEqAffineOperator(L1 + L2.A, L2.b)\n",
-    "+(L1::DiffEqAffineOperator, L2::DiffEqLinearOperator) = DiffEqAffineOperator(L1.A + L2, L1.b)\n",
-    "+(L1::DiffEqAffineOperator, L2::DiffEqAffineOperator) = DiffEqAffineOperator(L1.A + L2.A, L1.b + L2.b)\n",
-    "*(L1::DiffEqLinearOperator, L2::DiffEqAffineOperator) = DiffEqAffineOperator(L1 * L2.A, L1 * L2.b)\n",
-    "*(L1::DiffEqAffineOperator, L2::DiffEqLinearOperator) = DiffEqAffineOperator(L1.A * L2, L1.b)\n",
-    "*(L1::DiffEqAffineOperator, L2::DiffEqAffineOperator) = DiffEqAffineOperator(L1.A * L2.A, L1.A * L2.b + L1.b);"
+    "+(L1::DiffEqLinearOperator, A2::DiffEqAffineOperator) = DiffEqAffineOperator(L1 + A2.L, A2.b)\n",
+    "+(A1::DiffEqAffineOperator, L2::DiffEqLinearOperator) = DiffEqAffineOperator(A1.L + L2, A1.b)\n",
+    "+(A1::DiffEqAffineOperator, A2::DiffEqAffineOperator) = DiffEqAffineOperator(A1.L + A2.L, A1.b + A2.b)\n",
+    "*(L1::DiffEqLinearOperator, A2::DiffEqAffineOperator) = DiffEqAffineOperator(L1 * A2.L, L1 * A2.b)\n",
+    "*(A1::DiffEqAffineOperator, L2::DiffEqLinearOperator) = DiffEqAffineOperator(A1.L * L2, A1.b)\n",
+    "*(A1::DiffEqAffineOperator, A2::DiffEqAffineOperator) = DiffEqAffineOperator(A1.L * A2.L, A1.L * A2.b + A1.b);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 2. Operators on the interior (stencil convolution)\n",
+    "## 1.2 Discretization of the differential operator (stencil convolution)\n",
     "\n",
-    "The 2nd-order central difference approximation to $\\partial_x^2/2$ and the 1st-order upwind approximation to $\\partial_x$ are included. The general case can be modified from the stencil convolution code in DiffEqOperators.\n",
+    "The 2nd-order central difference approximation to $\\partial_x^2$ and the 1st-order upwind approximation to $\\partial_x$ are included. The general case can be modified from the stencil convolution code in DiffEqOperators.\n",
     "\n",
     "The upwind operator is implemented differently from DiffEqOperators, where the direction at each point is stored. Here only the left/right operator is constructed and we interpret\n",
     "\n",
     "$$ \\mu(x)\\partial_x = \\mu^+(x)\\partial_x^+ + \\mu^-(x)\\partial_x^- $$\n",
     "\n",
-    "This is the approach used in the write-up. Though maybe not as efficient, this is clearer both conceptually and from a coding standpoint."
+    "(Might not be a favorable approach, especially if we wish to extend to multidimensional upwind operators)"
    ]
   },
   {
@@ -161,15 +177,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 3. Boundary Maps (The $Q$ Operator)\n",
+    "# 1.3 Boundary extrapolation operator $Q$\n",
     "\n",
-    "(I'm calling the $Q$ operators the \"boundary maps\" temporarily, but I guess a better name should be used?)\n",
+    "Question: is it OK to shorthand \"boundary extrapolation operator\" as \"BEOperator\" or simply \"BE\"?\n",
     "\n",
     "A generic $Q$ from the generic boundary condition $Bu = b$ can be a bit difficult to implement, but the simple case of Dirichlet/Neumann BC is easy to handle.\n",
     "\n",
     "It should be easy to modify `AbsorbingBoundaryMap` and `ReflectingBoundaryMap` to incorporate boundaries that are absorbing at one end and reflecting at another.\n",
     "\n",
-    "The non-zero Dirichlet/Neumann boundary maps do not have their own type. Instead we construct the `Q` operator as an affine map, with `AbsorbingBoundaryMap` and `ReflectingBoundaryMap` its linear part."
+    "The non-zero Dirichlet/Neumann Qs do not have their own type. Instead we construct the operator as an affine map, with `AbsorbingBoundaryMap` and `ReflectingBoundaryMap` its linear part."
    ]
   },
   {
@@ -178,19 +194,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "struct AbsorbingBoundaryMap <: DiffEqLinearOperator\n",
+    "struct AbsorbingBE <: DiffEqLinearOperator\n",
     "    m::Int # number of interior points\n",
     "end\n",
     "\n",
-    "*(Q::AbsorbingBoundaryMap, x::Vector{Float64}) = [0.0; x; 0.0]\n",
-    "as_array(Q::AbsorbingBoundaryMap) = sparse([zeros(Q.m)'; eye(Q.m); zeros(Q.m)'])\n",
+    "*(Q::AbsorbingBE, x::Vector{Float64}) = [0.0; x; 0.0]\n",
+    "as_array(Q::AbsorbingBE) = sparse([zeros(Q.m)'; eye(Q.m); zeros(Q.m)'])\n",
     "\n",
-    "struct ReflectingBoundaryMap <: DiffEqLinearOperator\n",
+    "struct ReflectingBE <: DiffEqLinearOperator\n",
     "    m::Int # number of interior points\n",
     "end\n",
     "\n",
-    "*(Q::ReflectingBoundaryMap, x::Vector{Float64}) = [x[1]; x; x[end]]\n",
-    "as_array(Q::ReflectingBoundaryMap) = sparse([1.0 zeros(Q.m-1)'; eye(Q.m); zeros(Q.m-1)' 1.0]);"
+    "*(Q::ReflectingBE, x::Vector{Float64}) = [x[1]; x; x[end]]\n",
+    "as_array(Q::ReflectingBE) = sparse([1.0 zeros(Q.m-1)'; eye(Q.m); zeros(Q.m-1)' 1.0]);"
    ]
   },
   {
@@ -199,18 +215,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "function Dirichlet_boundary_map(m::Int, bl::Float64, br::Float64)\n",
+    "function Dirichlet_BE(m::Int, bl::Float64, br::Float64)\n",
     "    # y[1] = bl, y[end] = br\n",
-    "    Qa = AbsorbingBoundaryMap(m)\n",
-    "    Qb = [bl; zeros(m); br]\n",
-    "    DiffEqAffineOperator(Qa, Qb)\n",
+    "    L = AbsorbingBE(m)\n",
+    "    b = [bl; zeros(m); br]\n",
+    "    DiffEqAffineOperator(L, b)\n",
     "end\n",
     "\n",
-    "function Neumann_boundary_map(m::Int, dx::Float64, bl::Float64, br::Float64)\n",
+    "function Neumann_BE(m::Int, dx::Float64, bl::Float64, br::Float64)\n",
     "    # (y[2] - y[1])/dx = bl, (y[end] - y[end-1])/dx = br\n",
-    "    Qa = ReflectingBoundaryMap(m)\n",
-    "    Qb = [-bl*dx; zeros(m); br*dx]\n",
-    "    DiffEqAffineOperator(Qa, Qb)\n",
+    "    L = ReflectingBE(m)\n",
+    "    b = [-bl*dx; zeros(m); br*dx]\n",
+    "    DiffEqAffineOperator(L, b)\n",
     "end;"
    ]
   },
@@ -231,8 +247,8 @@
    "source": [
     "dx = 1.0\n",
     "u = [1.,2.,3.,4.]\n",
-    "QD = Dirichlet_boundary_map(4, 10.0, 20.0)\n",
-    "QN = Neumann_boundary_map(4, dx, 1.0, 2.0);"
+    "QD = Dirichlet_BE(4, 10.0, 20.0)\n",
+    "QN = Neumann_BE(4, dx, 1.0, 2.0);"
    ]
   },
   {
@@ -291,7 +307,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 4. Constructing operators for the Fokker-Planck equations\n",
+    "## 1.4 Constructing operators for the Fokker-Planck equations\n",
     "\n",
     "The most general case is in section 3.5 of the write-up:\n",
     "\n",
@@ -301,7 +317,7 @@
     "\n",
     "$$ \\mu(x)\\partial_x = \\mu^+(x)\\partial_x^+ + \\mu^-(x)\\partial_x^- $$\n",
     "\n",
-    "The discretized operators are expressed as the composition of an interior stencil convolution operator `A` and boundary map `Q` (they are generally affine). The drift and diffusion coefficients can be expressed as diagonal matrices (wrapped in a `DiffEqArrayOperator`).\n",
+    "The discretized operators are expressed as the composition of an interior stencil convolution operator `L` and boundary extrapolation operator `Q` (they are generally affine). The drift and diffusion coefficients can be expressed as diagonal matrices (wrapped in a `DiffEqArrayOperator`).\n",
     "\n",
     "The script below can be modified to represent each of the scenarios described in secition 3 of the write-up (except the mixed-BC case)."
    ]
@@ -314,7 +330,7 @@
     {
      "data": {
       "text/plain": [
-       "DiffEqOperatorComposition((AbsorbingBoundaryMap(10), DiffEqOperatorCombination((DiffEqOperatorComposition((DriftOperator(1.0, 10, true), DiffEqArrayOperator([0.123526 0.0 … 0.0 0.0; 0.0 0.77393 … 0.0 0.0; … ; 0.0 0.0 … 0.672812 0.0; 0.0 0.0 … 0.0 0.751455]))), DiffEqOperatorComposition((DriftOperator(1.0, 10, false), DiffEqArrayOperator([0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]))), DiffEqOperatorComposition((DiffusionOperator(1.0, 10), DiffEqArrayOperator([1.32813 0.0 … 0.0 0.0; 0.0 0.59207 … 0.0 0.0; … ; 0.0 0.0 … 1.87849 0.0; 0.0 0.0 … 0.0 1.22985])))))))"
+       "DiffEqOperatorComposition((AbsorbingBE(10), DiffEqOperatorCombination((DiffEqOperatorComposition((DriftOperator(1.0, 10, true), DiffEqArrayOperator([0.282496 0.0 … 0.0 0.0; 0.0 0.840896 … 0.0 0.0; … ; 0.0 0.0 … 0.518511 0.0; 0.0 0.0 … 0.0 0.896779]))), DiffEqOperatorComposition((DriftOperator(1.0, 10, false), DiffEqArrayOperator([0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]))), DiffEqOperatorComposition((DiffusionOperator(1.0, 10), DiffEqArrayOperator([1.76829 0.0 … 0.0 0.0; 0.0 1.59721 … 0.0 0.0; … ; 0.0 0.0 … 0.676772 0.0; 0.0 0.0 … 0.0 1.25609])))))))"
       ]
      },
      "execution_count": 11,
@@ -328,14 +344,14 @@
     "dx = 1.0\n",
     "xs = collect(1:N) * dx # interior nodes\n",
     "\n",
-    "# Interior operators\n",
-    "A1p = DriftOperator(dx, N, true)\n",
-    "A1m = DriftOperator(dx, N, false)\n",
-    "A2 = DiffusionOperator(dx, N)\n",
+    "# Discretization of the differential operators\n",
+    "L1p = DriftOperator(dx, N, true)\n",
+    "L1m = DriftOperator(dx, N, false)\n",
+    "L2 = DiffusionOperator(dx, N)\n",
     "\n",
     "# Boundary operators\n",
-    "Q = AbsorbingBoundaryMap(N)\n",
-    "# Q = Neumann_boundary_map(N, dx, 1.0, 2.0)\n",
+    "Q = AbsorbingBE(N)\n",
+    "# Q = Neumann_BE(N, dx, 1.0, 2.0)\n",
     "\n",
     "# Coefficients\n",
     "mu = rand(N)\n",
@@ -343,10 +359,10 @@
     "mum = [mu[i] < 0.0 ? mu[i] : 0.0 for i in 1:N]\n",
     "sigma = rand(N) + 1.0\n",
     "\n",
-    "# Construct L\n",
-    "L1 = DiffEqArrayOperator(Diagonal(mup)) * A1p + DiffEqArrayOperator(Diagonal(mum)) * A1m\n",
-    "L2 = DiffEqArrayOperator(Diagonal(sigma.^2 / 2)) * A2\n",
-    "L = (L1 + L2) * Q"
+    "# Construct the final product\n",
+    "Ldrift = DiffEqArrayOperator(Diagonal(mup)) * L1p + DiffEqArrayOperator(Diagonal(mum)) * L1m\n",
+    "Ldiffusion = DiffEqArrayOperator(Diagonal(sigma.^2 / 2)) * L2\n",
+    "A = (Ldrift + Ldiffusion) * Q"
    ]
   },
   {
@@ -365,16 +381,16 @@
      "data": {
       "text/plain": [
        "10-element Array{Float64,1}:\n",
-       " 32.1917\n",
-       " 61.8482\n",
-       " 54.584 \n",
-       " 47.3014\n",
-       " 46.0182\n",
-       " 43.7368\n",
-       " 38.5641\n",
-       " 31.9659\n",
-       " 22.1972\n",
-       " 11.7271"
+       " 19.0086\n",
+       " 34.9524\n",
+       " 42.3442\n",
+       " 45.8283\n",
+       " 46.1967\n",
+       " 44.579 \n",
+       " 38.5766\n",
+       " 32.2452\n",
+       " 24.5824\n",
+       " 11.3082"
       ]
      },
      "execution_count": 12,
@@ -383,13 +399,15 @@
     }
    ],
    "source": [
-    "# Solve the HJBE (rI - L)u = x\n",
+    "# Solve the HJBE (rI - A)u = x\n",
+    "# In the complete version, we can just do (r*I - A) \\ u\n",
+    "# For now we will break the access barrier and get dirty\n",
     "r = 0.05\n",
-    "if isa(L, DiffEqAffineOperator)\n",
-    "    LHS = r*speye(N) - as_array(L.A)\n",
-    "    RHS = xs + L.b\n",
+    "if isa(A, DiffEqAffineOperator)\n",
+    "    LHS = r*speye(N) - as_array(A.L)\n",
+    "    RHS = xs + A.b\n",
     "else\n",
-    "    LHS = r*speye(N) - as_array(L)\n",
+    "    LHS = r*speye(N) - as_array(A)\n",
     "    RHS = xs\n",
     "end\n",
     "u = LHS \\ RHS"


### PR DESCRIPTION
[Notebook link](https://nbviewer.jupyter.org/github/MSeeker1340/PDERoadmap/blob/operator_interface_prototype/Discretizing%20Linear%20Operators.ipynb)

Updated the notations to conform with the convention discussed today. @jlperla can you take a look and confirm the notation choices? I've also expanded on the operator interface so that scalar multiplication and subtractions are now supported. The example in the last section now no longer uses field access.

As per the discussion of yesterday, currently what I'm working on is to embed coefficients into the discretizations of derivative operators along with the `update_coefficients!` interface, with the main focus being on the upwind operators. 

@ChrisRackauckas Could use your opinion on this. I've been thinking about the `update_coefficients!` implementation and it occurs to me that this is not the only way to supply new coefficients to the operators. Using the current `DiffEqArrayOperator` as an example (this also works with the embedded coefficients approach):

```julia
>>> mu = ones(2); L = DiffEqArrayOperator(Diagonal(mu))

DiffEqArrayOperator([1.0 0.0; 0.0 1.0])
```

Since both `Diagonal` and `DiffEqArrayOperator` stores references instead of copying the array, we can change `L` directly by modifying `mu`:

```julia
>>> mu[1] = 100.0; L

DiffEqArrayOperator([100.0 0.0; 0.0 1.0])
```

So for an iterative algorithm that involves updating coefficients of a differential operator, the user can do something like

```julia
# Initialization
mu = [...]
sigma = [...]
L = DiffEqArrayOperator(Diagonal(mu)) * ... + DiffEqArrayOperator(Diagonal(sigma)) * ...
while ...
    # compute things
    # update mu and sigma
end
```

And note there's no need to explicitly update `L` because it has been handled through reference.

Now I understand this might feel unsafe due to the coefficients arrays being global variables. But as long as we package everything inside a function (which we need to do for the iterative algorithm anyway) this should be fine in my opinion.

This is not to say that we don't need `update_coefficients!` anymore --- the ODE solvers can still benefit from such a method. But for @jlperla's specific needs I think the direct update approach would suffice.