### PR TITLE
Coefficients embedded operators

### DIFF
--- a/Discretizing Linear Operators.ipynb
+++ b/Discretizing Linear Operators.ipynb
@@ -344,7 +344,7 @@
     {
      "data": {
       "text/plain": [
-       "DiffEqOperatorComposition((AbsorbingBE(10), DiffEqOperatorCombination((1.0, 1.0, 1.0), (DiffEqOperatorComposition((DriftOperator(1.0, 10, true), DiffEqArrayOperator([0.887661 0.0 … 0.0 0.0; 0.0 0.213112 … 0.0 0.0; … ; 0.0 0.0 … 0.436606 0.0; 0.0 0.0 … 0.0 0.569388]))), DiffEqOperatorComposition((DriftOperator(1.0, 10, false), DiffEqArrayOperator([0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]))), DiffEqOperatorComposition((DiffusionOperator(1.0, 10), DiffEqArrayOperator([1.89194 0.0 … 0.0 0.0; 0.0 0.597414 … 0.0 0.0; … ; 0.0 0.0 … 0.539805 0.0; 0.0 0.0 … 0.0 0.94818])))))))"
+       "DiffEqOperatorComposition((AbsorbingBE(10), DiffEqOperatorCombination((1.0, 1.0, 1.0), (DiffEqOperatorComposition((DriftOperator(1.0, 10, true), DiffEqArrayOperator([0.174104 0.0 … 0.0 0.0; 0.0 0.952114 … 0.0 0.0; … ; 0.0 0.0 … 0.761347 0.0; 0.0 0.0 … 0.0 0.378555]))), DiffEqOperatorComposition((DriftOperator(1.0, 10, false), DiffEqArrayOperator([0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]))), DiffEqOperatorComposition((DiffusionOperator(1.0, 10), DiffEqArrayOperator([1.4769 0.0 … 0.0 0.0; 0.0 1.72067 … 0.0 0.0; … ; 0.0 0.0 … 0.689607 0.0; 0.0 0.0 … 0.0 1.54688])))))))"
       ]
      },
      "execution_count": 11,
@@ -395,16 +395,16 @@
      "data": {
       "text/plain": [
        "10-element Array{Float64,1}:\n",
-       " 24.4109\n",
-       " 37.4853\n",
-       " 45.6853\n",
-       " 52.2336\n",
-       " 51.9707\n",
-       " 50.2344\n",
-       " 46.5129\n",
-       " 37.9023\n",
-       " 30.9117\n",
-       " 15.7658"
+       " 19.0869\n",
+       " 35.8929\n",
+       " 43.2801\n",
+       " 46.9296\n",
+       " 46.775 \n",
+       " 44.3825\n",
+       " 40.6502\n",
+       " 34.9724\n",
+       " 23.8643\n",
+       " 13.6993"
       ]
      },
      "execution_count": 12,
@@ -417,6 +417,157 @@
     "r = 0.05\n",
     "LHS = DiffEqArrayOperator(r*speye(N)) - A\n",
     "u = LHS \\ xs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.5 Alternative: embedding coefficients within the discretization operators\n",
+    "\n",
+    "It might be preferrable to use a single type for a differential operator prepended with coefficients, e.g. $\\mu(x)\\partial_x$ and $\\frac{\\sigma(x)^2}{2}\\partial_x^2$, instead of constructing them as operator compositions. Possible advantages:\n",
+    "\n",
+    "- Faster `A_mul_B!`\n",
+    "\n",
+    "- Cleaner type signature (also for `update_coefficients!` in the time-dependent case)\n",
+    "\n",
+    "- Better handling of upwind operators, especially in >= 1D"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "struct DiffusionOperatorC{Cs} <: DiffEqLinearOperator\n",
+    "    dx::Float64\n",
+    "    m::Int # number of interior points\n",
+    "    coeffs::Cs # nothing or scalar or vector\n",
+    "end\n",
+    "DiffusionOperatorC(dx, m, coeffs=nothing) = DiffusionOperatorC{typeof(coeffs)}(dx, m, coeffs)\n",
+    "\n",
+    "# Handle L*x differently depending on the type of coefficients\n",
+    "*(L::DiffusionOperatorC{Void}, x::Vector{Float64}) = [x[i] + x[i+2] - 2*x[i+1] for i in 1:L.m] / L.dx^2\n",
+    "*(L::DiffusionOperatorC{Float64}, x::Vector{Float64}) = [x[i] + x[i+2] - 2*x[i+1] for i in 1:L.m] * L.coeffs / L.dx^2\n",
+    "*(L::DiffusionOperatorC{Vector{Float64}}, x::Vector{Float64}) = [L.coeffs[i] * (x[i] + x[i+2] - 2*x[i+1]) \n",
+    "    for i in 1:L.m] / L.dx^2\n",
+    "\n",
+    "# Override scalar multiplication\n",
+    "*(α::Float64, L::DiffusionOperatorC{Void}) = DiffusionOperatorC(L.dx, L.m, α)\n",
+    "*(α::Float64, L::DiffusionOperatorC{T}) where {T <: Union{Float64,Vector{Float64}}} = DiffusionOperatorC(\n",
+    "    L.dx, L.m, α*L.coeffs)\n",
+    "\n",
+    "as_array(L::DiffusionOperatorC{Void}) = spdiagm((ones(L.m), -2*ones(L.m), ones(L.m)), (0,1,2)) / L.dx^2;\n",
+    "as_array(L::DiffusionOperatorC{Float64}) = spdiagm((ones(L.m), -2*ones(L.m), ones(L.m)), (0,1,2)) * L.coeffs / L.dx^2;\n",
+    "as_array(L::DiffusionOperatorC{Vector{Float64}}) = spdiagm(L.coeffs) * spdiagm(\n",
+    "    (ones(L.m), -2*ones(L.m), ones(L.m)), (0,1,2)) / L.dx^2;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "struct DriftOperatorC{Cs} <: DiffEqLinearOperator\n",
+    "    dx::Float64\n",
+    "    m::Int # number of interior points\n",
+    "    coeffs::Cs # scalar or vector\n",
+    "end\n",
+    "DriftOperatorC(dx, m, coeffs=1.0) = DriftOperatorC{typeof(coeffs)}(dx, m, coeffs)\n",
+    "\n",
+    "# Handle L*x differently depending on the type of coefficients\n",
+    "function *(L::DriftOperatorC{Float64}, x::Vector{Float64})\n",
+    "    if L.coeffs > 0 # right drift\n",
+    "        [x[i+1] - x[i] for i in 1:L.m] * L.coeffs / L.dx\n",
+    "    else # left drift\n",
+    "        [x[i+2] - x[i+1] for i in 1:L.m] * L.coeffs / L.dx\n",
+    "    end\n",
+    "end\n",
+    "function *(L::DriftOperatorC{Vector{Float64}}, x::Vector{Float64})\n",
+    "    out = zeros(L.m)\n",
+    "    for i in 1:L.m\n",
+    "        c = L.coeffs[i]\n",
+    "        if c > 0 # right drift\n",
+    "            out[i] = c/L.dx * (x[i+1] - x[i])\n",
+    "        else # left drift\n",
+    "            out[i] = c/L.dx * (x[i+2] - x[i+1])\n",
+    "        end\n",
+    "    end\n",
+    "    out\n",
+    "end\n",
+    "\n",
+    "# Override scalar multiplication\n",
+    "*(α::Float64, L::DriftOperatorC{T}) where {T <: Union{Float64,Vector{Float64}}} = DriftOperatorC(\n",
+    "    L.dx, L.m, α*L.coeffs)\n",
+    "\n",
+    "function as_array(L::DriftOperatorC{Float64})\n",
+    "    if L.coeffs > 0 # right drift\n",
+    "        spdiagm((-ones(L.m), ones(L.m), zeros(L.m)), (0,1,2)) * L.coeffs / L.dx\n",
+    "    else # left drift\n",
+    "        spdiagm((zeros(L.m), -ones(L.m), ones(L.m)), (0,1,2)) * L.coeffs / L.dx\n",
+    "    end\n",
+    "end\n",
+    "function as_array(L::DriftOperatorC{Vector{Float64}})\n",
+    "    out = zeros(L.m, L.m+2)\n",
+    "    for j in 1:L.m\n",
+    "        c = L.coeffs[j]\n",
+    "        if c > 0 # right drift\n",
+    "            out[j,j] = -c/L.dx\n",
+    "            out[j,j+1] = c/L.dx\n",
+    "        else # left drift\n",
+    "            out[j,j+1] = -c/L.dx\n",
+    "            out[j,j+2] = c/L.dx\n",
+    "        end\n",
+    "    end\n",
+    "    out\n",
+    "end;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Test equivalence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "L2 * u ≈ L2alt * u = true\n",
+      "as_array(L2) ≈ as_array(L2alt) = true\n",
+      "L1 * u ≈ L1alt * u = true\n",
+      "as_array(L1) ≈ as_array(L1alt) = true\n"
+     ]
+    }
+   ],
+   "source": [
+    "N = 10\n",
+    "mu = rand(N)\n",
+    "mup = [x > 0 ? x : 0.0 for x in mu]\n",
+    "mum = [x < 0 ? x : 0.0 for x in mu]\n",
+    "sigma = rand(N)\n",
+    "u = rand(N + 2)\n",
+    "\n",
+    "# Diffusion operator\n",
+    "L2 = DiffEqArrayOperator(Diagonal(sigma.^2/2)) * DiffusionOperator(dx, N) # original\n",
+    "L2alt = DiffusionOperatorC(dx, N, sigma.^2/2) # coefficients-embedded\n",
+    "@show L2*u ≈ L2alt * u\n",
+    "@show as_array(L2) ≈ as_array(L2alt)\n",
+    "\n",
+    "# Drift Operator\n",
+    "L1 = DiffEqArrayOperator(Diagonal(mup)) * DriftOperator(dx, N, true) + \n",
+    "    DiffEqArrayOperator(Diagonal(mum)) * DriftOperator(dx, N, false)\n",
+    "L1alt = DriftOperatorC(dx, N, mu)\n",
+    "@show L1*u ≈ L1alt*u\n",
+    "@show as_array(L1) ≈ as_array(L1alt);"
    ]
   },
   {

--- a/Discretizing Linear Operators.ipynb
+++ b/Discretizing Linear Operators.ipynb
@@ -344,7 +344,7 @@
     {
      "data": {
       "text/plain": [
-       "DiffEqOperatorComposition((AbsorbingBE(10), DiffEqOperatorCombination((1.0, 1.0, 1.0), (DiffEqOperatorComposition((DriftOperator(1.0, 10, true), DiffEqArrayOperator([0.174104 0.0 … 0.0 0.0; 0.0 0.952114 … 0.0 0.0; … ; 0.0 0.0 … 0.761347 0.0; 0.0 0.0 … 0.0 0.378555]))), DiffEqOperatorComposition((DriftOperator(1.0, 10, false), DiffEqArrayOperator([0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]))), DiffEqOperatorComposition((DiffusionOperator(1.0, 10), DiffEqArrayOperator([1.4769 0.0 … 0.0 0.0; 0.0 1.72067 … 0.0 0.0; … ; 0.0 0.0 … 0.689607 0.0; 0.0 0.0 … 0.0 1.54688])))))))"
+       "DiffEqOperatorComposition((AbsorbingBE(10), DiffEqOperatorCombination((1.0, 1.0, 1.0), (DiffEqOperatorComposition((DriftOperator(1.0, 10, true), DiffEqArrayOperator([0.110363 0.0 … 0.0 0.0; 0.0 0.975709 … 0.0 0.0; … ; 0.0 0.0 … 0.641835 0.0; 0.0 0.0 … 0.0 0.131701]))), DiffEqOperatorComposition((DriftOperator(1.0, 10, false), DiffEqArrayOperator([0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]))), DiffEqOperatorComposition((DiffusionOperator(1.0, 10), DiffEqArrayOperator([1.9639 0.0 … 0.0 0.0; 0.0 1.91881 … 0.0 0.0; … ; 0.0 0.0 … 0.792768 0.0; 0.0 0.0 … 0.0 1.60184])))))))"
       ]
      },
      "execution_count": 11,
@@ -395,16 +395,16 @@
      "data": {
       "text/plain": [
        "10-element Array{Float64,1}:\n",
-       " 19.0869\n",
-       " 35.8929\n",
-       " 43.2801\n",
-       " 46.9296\n",
-       " 46.775 \n",
-       " 44.3825\n",
-       " 40.6502\n",
-       " 34.9724\n",
-       " 23.8643\n",
-       " 13.6993"
+       " 18.2949\n",
+       " 35.5184\n",
+       " 43.867 \n",
+       " 46.5879\n",
+       " 47.308 \n",
+       " 44.8502\n",
+       " 40.9203\n",
+       " 35.5244\n",
+       " 27.2429\n",
+       " 16.0318"
       ]
      },
      "execution_count": 12,
@@ -431,7 +431,11 @@
     "\n",
     "- Cleaner type signature (also for `update_coefficients!` in the time-dependent case)\n",
     "\n",
-    "- Better handling of upwind operators, especially in >= 1D"
+    "- Better handling of upwind operators, especially in >= 1D\n",
+    "\n",
+    "To avoid conflicting with the previous implementations I appended a C at the end of `DiffusionOperator` and `DriftOperator`. There's no actual need of using separate types.\n",
+    "\n",
+    "For a scalar `a`, `a*L` yields a singleton `DiffEqOperatorCombination` with `a` as the coefficient of `L`. We need to override this behavior so that `a` acts directly on `L`'s coefficient field. There's still the problem of `a*L` when `L` itself is a combination of the coefficients-embedded operators, however, but we can probably modify the code for that and check to see if any of `L`'s components have overrided scalar multiplication methods."
    ]
   },
   {
@@ -529,7 +533,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Test equivalence"
+    "Test equivalence between the old and new implementations:"
    ]
   },
   {
@@ -550,6 +554,7 @@
    ],
    "source": [
     "N = 10\n",
+    "dx = 1.0\n",
     "mu = rand(N)\n",
     "mup = [x > 0 ? x : 0.0 for x in mu]\n",
     "mum = [x < 0 ? x : 0.0 for x in mu]\n",
@@ -568,6 +573,39 @@
     "L1alt = DriftOperatorC(dx, N, mu)\n",
     "@show L1*u ≈ L1alt*u\n",
     "@show as_array(L1) ≈ as_array(L1alt);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now for a sample iterative algorithm involving variable coefficients:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize coefficients arrays\n",
+    "N = 10\n",
+    "dx = 1.0\n",
+    "mu = rand(N)\n",
+    "sigma = rand(N)\n",
+    "D = sigma.^2 / 2\n",
+    "\n",
+    "# Build operators from coefficients arrays\n",
+    "L = DriftOperatorC(dx, N, mu) + DiffusionOperatorC(dx, N, D)\n",
+    "\n",
+    "# Loop\n",
+    "err = inf\n",
+    "tol = 1e-5\n",
+    "while err > tol\n",
+    "    # Compute things with L\n",
+    "    # Update mu and D\n",
+    "    # Update err\n",
+    "end"
    ]
   },
   {


### PR DESCRIPTION
[section link](https://nbviewer.jupyter.org/github/MSeeker1340/PDERoadmap/blob/operator_interface_prototype/Discretizing%20Linear%20Operators.ipynb#1.5-Alternative:-embedding-coefficients-within-the-discretization-operators)

The main point is that as @ChrisRackauckas points out, separating $\mu(x)\partial_x$ into $\mu_+(x)\partial_+(x) + \mu_-(x)\partial_-(x)$ does not generalize well to multiple dimensions (also it's not very elegant and slower by a factor of two). What we should really do is something similar to the existing implementation of upwind operators, i.e. include the directions/coefficients in the operator itself.

Now there are two ways going forward from here: either we use this as a basis and have every differential operators include a field for coefficients, or we constrain this approach only to upwind operators and keep the central differencing operators coefficients-free. The first way is more consistent in terms of interface, but would result in a lot of redundant code (after all, the need to embed coefficients only exist for upwind operators). Personally I prefer the second approach, but I should leave this up to discussion.

Do note that although the construction of `L` in the last cell looks very concise, in general we still need to use operator compositions now and then. For example, for the forward Kolmogorov operators the derivatives come after the coefficients are applied, so we need something like `L = DiffusionOperator(dx,N) * DiffEqArrayOperator(Diagonal(D))`.

(By the way, for the forward Kolmogorov equation, how does upwind operators work? Specifically, do we use Leibniz rule on $\partial_x(\mu(x)u)$ = $\mu(x)\partial_xu + \partial_x\mu(x)u$ and convert to the case when the coefficients are prepended? And what direction should we take to evaluate $\partial_x\mu(x)$?)

@jlperla I have included an example of how an iterative algorithm with coefficients update would work. As I discussed in the last PR, because `mu` and `D` are stored as references their changes will be reflected in `L`, so there's no need for `update_coefficients!`. On the other hand if you're worried about the external dependency, we can go back to the `update_coefficients!` route.