### PR TITLE
Function composition interface

### DIFF
--- a/Discretizing Linear Operators.ipynb
+++ b/Discretizing Linear Operators.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "- `b` denotes the bias of an affine operator\n",
     "\n",
-    "- (Not discussed but I guess we may as well make the call?) `M` for raw matrices (`AbstractMatrix`) and `x`, `y`, `u`, etc for vectors."
+    "- `M` for raw matrices (`AbstractMatrix`) and `x`, `y`, `u`, etc for vectors."
    ]
   },
   {
@@ -30,16 +30,16 @@
     "import Base: +, -, *, \\\n",
     "\n",
     "abstract type DiffEqOperator end\n",
-    "abstract type DiffEqLinearOperator <: DiffEqOperator end"
+    "abstract type DiffEqLinearOperator <: DiffEqOperator end\n",
+    "\n",
+    "update_coefficients!(::DiffEqOperator,u,p,t) = nothing; # Default update behavior"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 1. Constant case (i.e. no `update_coefficients!`)\n",
-    "\n",
-    "## 1.1 Abstract operator interface\n",
+    "# 1. Abstract operator interface\n",
     "\n",
     "Below is a simplified operator interface used in my new interface draft. Basically we want to express lazy addition and multiplication of linear operators naturally using `+` and `*`. The `as_array` interface returns the most suitable (dense/sparse) representation of the underlying operator as an `AbstractMatrix` (or should we treat this as a type conversion and just use `AbstractMatrix`?).\n",
     "\n",
@@ -66,6 +66,7 @@
     "    Ls::Tuple{Vararg{DiffEqLinearOperator}}\n",
     "end\n",
     "\n",
+    "update_coefficients!(L::DiffEqOperatorCombination,u,p,t) = foreach(Lk -> update_coefficients!(Lk,u,p,t), L.Ls)\n",
     "*(L::DiffEqOperatorCombination, x::Vector{Float64}) = sum(ck * (Lk*x) for (ck,Lk) in zip(L.cs,L.Ls))\n",
     "as_array(L::DiffEqOperatorCombination) = sum(ck * as_array(Lk) for (ck,Lk) in zip(L.cs,L.Ls))\n",
     "\n",
@@ -73,6 +74,7 @@
     "    Ls::Tuple{Vararg{DiffEqLinearOperator}}\n",
     "end\n",
     "\n",
+    "update_coefficients!(L::DiffEqOperatorComposition,u,p,t) = foreach(Lk -> update_coefficients!(Lk,u,p,t), L.Ls)\n",
     "*(L::DiffEqOperatorComposition, x::Vector{Float64}) = foldl((u, Lk) -> Lk*u, x, L.Ls)\n",
     "as_array(L::DiffEqOperatorComposition) = prod(as_array, reverse(L.Ls))\n",
     "\n",
@@ -81,6 +83,8 @@
     "    b::Vector{Float64}\n",
     "end\n",
     "\n",
+    "# TODO: time-dependent bias\n",
+    "update_coefficients!(A::DiffEqAffineOperator,u,p,t) = update_coefficients!(A.L,u,p,t)\n",
     "*(A::DiffEqAffineOperator, x::Vector{Float64}) = A.L * x + A.b;"
    ]
   },
@@ -133,15 +137,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1.2 Discretization of the differential operator (stencil convolution)\n",
+    "# 2. Scalar field (\"coefficients\") operator\n",
     "\n",
-    "The 2nd-order central difference approximation to $\\partial_x^2$ and the 1st-order upwind approximation to $\\partial_x$ are included. The general case can be modified from the stencil convolution code in DiffEqOperators.\n",
+    "Represents the linear operator\n",
     "\n",
-    "The upwind operator is implemented differently from DiffEqOperators, where the direction at each point is stored. Here only the left/right operator is constructed and we interpret\n",
+    "$$ \\alpha: u(x) \\rightarrow \\alpha(x)u(x) $$\n",
     "\n",
-    "$$ \\mu(x)\\partial_x = \\mu^+(x)\\partial_x^+ + \\mu^-(x)\\partial_x^- $$\n",
+    "$\\alpha$ may in general also depend on `(u,p,t)`. In the constructor for `ScalarField`, `α` has the signature `α(u,p,t,x) -> y`. The grid type is just `Vector{Float64}`; we can implement a sophisticated grid type after the discussions [here](https://github.com/JuliaDiffEq/PDERoadmap/issues/4).\n",
     "\n",
-    "(Might not be a favorable approach, especially if we wish to extend to multidimensional upwind operators)"
+    "Note that in the constructor `αgrid` is uninitialized. It only obtains value after `update_coefficients!` is called. This should not be a real problem though as the `L(u,p,t)` interface always calls `update_coefficients!` on itself."
    ]
   },
   {
@@ -150,48 +154,350 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "struct DiffusionOperator <: DiffEqLinearOperator\n",
-    "    dx::Float64\n",
-    "    m::Int # number of interior points\n",
+    "struct ScalarField <: DiffEqLinearOperator\n",
+    "    α\n",
+    "    grid::Vector{Float64}\n",
+    "    αgrid::Vector{Float64}\n",
     "end\n",
-    "\n",
-    "*(L::DiffusionOperator, x::Vector{Float64}) = [x[i] + x[i+2] - 2*x[i+1] for i in 1:L.m] / L.dx^2\n",
-    "as_array(L::DiffusionOperator) = spdiagm((ones(L.m), -2*ones(L.m), ones(L.m)), (0,1,2)) / L.dx^2;"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "struct DriftOperator <: DiffEqLinearOperator\n",
-    "    dx::Float64\n",
-    "    m::Int # number of interior points\n",
-    "    direction::Bool # true = right, false = left\n",
-    "end\n",
-    "\n",
-    "function *(L::DriftOperator, x::Vector{Float64})\n",
-    "    if L.direction # right drift\n",
-    "        [x[i+1] - x[i] for i in 1:L.m] / L.dx\n",
-    "    else # left drift\n",
-    "        [x[i+2] - x[i+1] for i in 1:L.m] / L.dx\n",
+    "ScalarField(α, grid::Vector{Float64}) = ScalarField(α, grid, similar(grid)) # αgrid is uninitialized\n",
+    "function update_coefficients!(L::ScalarField,u,p,t)\n",
+    "    for i in 1:length(grid)\n",
+    "        L.αgrid[i] = L.α(u,p,t,grid[i])\n",
     "    end\n",
     "end\n",
-    "function as_array(L::DriftOperator)\n",
-    "    if L.direction # right drift\n",
-    "        spdiagm((-ones(L.m), ones(L.m), zeros(L.m)), (0,1,2)) / L.dx\n",
-    "    else # left drift\n",
-    "        spdiagm((zeros(L.m), -ones(L.m), ones(L.m)), (0,1,2)) / L.dx\n",
-    "    end\n",
-    "end;"
+    "\n",
+    "*(L::ScalarField, u::Vector{Float64}) = L.αgrid .* u\n",
+    "as_array(L::ScalarField) = Diagonal(L.αgrid);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 1.3 Boundary extrapolation operator $Q$\n",
+    "Example:\n",
+    "\n",
+    "$$\\alpha(x) = Kx^2,\\quad K\\in\\mathbb{R}$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ScalarField(#11, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0], [2.32555e-315, 7.15942e-316, 2.32555e-315, 7.16065e-316, 7.1655e-316, 0.0])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grid = collect(0.0:1.0:5.0)\n",
+    "α = (u,p,t,x) -> p * x^2\n",
+    "Lα = ScalarField(α, grid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lα.αgrid = [0.0, 1.0, 4.0, 9.0, 16.0, 25.0]\n",
+      "Lα * u = [0.0, 0.841471, 3.63719, 1.27008, -12.1088, -23.9731]\n"
+     ]
+    }
+   ],
+   "source": [
+    "u = sin.(grid)\n",
+    "p = 1.0\n",
+    "t = 0.0\n",
+    "\n",
+    "update_coefficients!(Lα,u,p,t)\n",
+    "@show Lα.αgrid\n",
+    "@show Lα * u;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lα.αgrid = [0.0, 2.0, 8.0, 18.0, 32.0, 50.0]\n",
+      "Lα * u = [0.0, 1.68294, 7.27438, 2.54016, -24.2177, -47.9462]\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = 2.0\n",
+    "update_coefficients!(Lα,u,p,t)\n",
+    "@show Lα.αgrid\n",
+    "@show Lα * u;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 3. Discretization of differenctial operators\n",
+    "\n",
+    "The 2nd-order central difference approximation to $\\partial_x^2$ is hand-coded here. The general case can be modified from `DerivativeOperator` from DiffEqOperators.\n",
+    "\n",
+    "The 1st-order upwind difference approximation to $\\partial_x$ is also included here but operations on `FirstDifferenceUpwind` will throw an error (because the \"bare\" operator does not know which is the upwind direction). It is meant as a placeholder and should be used in conjunction with prepended scalar field/coefficients.\n",
+    "\n",
+    "In this notebook I shall assume the grid to be uniform and represents the interior points. The grid spacing is calculated as `dx = grid[2] - grid[1]`. While this is a bit ugly, the interface will be much better once we incorporate our own `Interval` or `Grid` types."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "struct SecondDifferenceCentral <: DiffEqLinearOperator\n",
+    "    grid::Vector{Float64}\n",
+    "end\n",
+    "\n",
+    "function *(L::SecondDifferenceCentral, x::Vector{Float64})\n",
+    "    m = length(L.grid)\n",
+    "    dx = L.grid[2] - L.grid[1]\n",
+    "    [x[i] + x[i+2] - 2*x[i+1] for i in 1:m] / dx^2\n",
+    "end\n",
+    "function as_array(L::SecondDifferenceCentral)\n",
+    "    m = length(L.grid)\n",
+    "    dx = L.grid[2] - L.grid[1]\n",
+    "    spdiagm((ones(m), -2*ones(m), ones(m)), (0,1,2)) / dx^2\n",
+    "end\n",
+    "\n",
+    "struct FirstDifferenceUpwind <: DiffEqLinearOperator\n",
+    "    grid::Vector{Float64}\n",
+    "end\n",
+    "\n",
+    "struct UpwindDirectionUnknownError end\n",
+    "*(::FirstDifferenceUpwind, x) = throw(UpwindDirectionUnknownError())\n",
+    "as_array(::FirstDifferenceUpwind) = throw(UpwindDirectionUnknownError());"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We're now in a position to implement the function composition interface\n",
+    "\n",
+    "```julia\n",
+    "α1 = (u,p,t,x) -> ...\n",
+    "α2 = (u,p,t,x) -> ...\n",
+    "L = α1 * FirstDifferenceUpwind(grid) + α2 * SecondDifferenceCentral(grid)\n",
+    "```\n",
+    "\n",
+    "For the central differencing operators, we can simply interpret `α2 * SecondDifferenceCentral(grid)` as the composition of `ScalarField(α2,grid)` and `SecondDifferenceCentral(grid)`. On the other hand, for the upwind operators we need to fuse them into a composite type because the scalar field/coefficient determines the differencing directions.\n",
+    "\n",
+    "Question: what if we want an α that is a functor?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Central differencing\n",
+    "*(α::Function, L::SecondDifferenceCentral) = ScalarField(α, L.grid) * L\n",
+    "\n",
+    "# Upwind differencing\n",
+    "struct UpwindOperator{C,O} <: DiffEqLinearOperator\n",
+    "    coeffs::C\n",
+    "    raw_operator::O\n",
+    "end\n",
+    "*(α::Float64, L::FirstDifferenceUpwind) = UpwindOperator(α, L)\n",
+    "*(α::Function, L::FirstDifferenceUpwind) = UpwindOperator(ScalarField(α, L.grid), L)\n",
+    "update_coefficients!(L::UpwindOperator{ScalarField, O},u,p,t) where {O} = update_coefficients!(L.coeffs,u,p,t)\n",
+    "\n",
+    "# In the production code, *(L::UpwindOperator, x) will be generic (uses L.stencil_up \n",
+    "# and L.stencil_down, for example). For this notebook I will simply implmement the \n",
+    "# specific case for FirstDifferenceUpwind\n",
+    "function *(L::UpwindOperator{Float64, FirstDifferenceUpwind}, x::Vector{Float64})\n",
+    "    m = length(L.raw_operator.grid)\n",
+    "    dx = L.raw_operator.grid[2] - L.raw_operator.grid[1]\n",
+    "    if L.coeffs > 0 # right drift\n",
+    "        L.coeffs * [x[i+1] - x[i] for i in 1:m] / dx\n",
+    "    else # left drift\n",
+    "        L.coeffs * [x[i+2] - x[i+1] for i in 1:m] / dx\n",
+    "    end\n",
+    "end\n",
+    "function *(L::UpwindOperator{ScalarField, FirstDifferenceUpwind}, x::Vector{Float64})\n",
+    "    m = length(L.raw_operator.grid)\n",
+    "    dx = L.raw_operator.grid[2] - L.raw_operator.grid[1]\n",
+    "    out = zeros(m)\n",
+    "    for i in 1:m\n",
+    "        c = L.coeffs.αgrid[i]\n",
+    "        if c > 0 # right drift\n",
+    "            out[i] = c/dx * (x[i+1] - x[i])\n",
+    "        else # left drift\n",
+    "            out[i] = c/dx * (x[i+2] - x[i+1])\n",
+    "        end\n",
+    "    end\n",
+    "    out\n",
+    "end\n",
+    "\n",
+    "function as_array(L::UpwindOperator{Float64, FirstDifferenceUpwind})\n",
+    "    m = length(L.raw_operator.grid)\n",
+    "    dx = L.raw_operator.grid[2] - L.raw_operator.grid[1]\n",
+    "    if L.coeffs > 0 # right drift\n",
+    "        spdiagm((-ones(m), ones(m), zeros(m)), (0,1,2)) / dx\n",
+    "    else # left drift\n",
+    "        spdiagm((zeros(m), -ones(m), ones(m)), (0,1,2)) / dx\n",
+    "    end    \n",
+    "end\n",
+    "function as_array(L::UpwindOperator{ScalarField, FirstDifferenceUpwind})\n",
+    "    m = length(L.raw_operator.grid)\n",
+    "    dx = L.raw_operator.grid[2] - L.raw_operator.grid[1]\n",
+    "    out = zeros(m,m+2)\n",
+    "    for j = 1:m\n",
+    "        c = L.coeffs.αgrid[j]\n",
+    "        if c > 0 # right drift\n",
+    "            out[j,j] = -c/dx\n",
+    "            out[j,j+1] = c/dx\n",
+    "        else # left drift\n",
+    "            out[j,j+1] = -c/dx\n",
+    "            out[j,j+2] = c/dx\n",
+    "        end\n",
+    "    end\n",
+    "    sparse(out)\n",
+    "end;\n",
+    "\n",
+    "# TODO: implement scalar/ScalarField multiplication on UpwindOperator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DiffEqOperatorCombination((1.0, 1.0), (UpwindOperator{ScalarField,FirstDifferenceUpwind}(ScalarField(#19, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0], [8.29573e-316, 9.88267e-316, 2.23096e-315, 9.17226e-316, 8.14163e-316, 2.17222e-315]), FirstDifferenceUpwind([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])), DiffEqOperatorComposition((SecondDifferenceCentral([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]), ScalarField(#21, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0], [2.23108e-315, 7.20971e-316, 7.19168e-316, 2.23108e-315, 2.23108e-315, 2.24314e-315])))))"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grid = collect(0.0:1.0:5.0)\n",
+    "u = rand(8)\n",
+    "α1 = (u,p,t,x) -> 1.01*x\n",
+    "α2 = (u,p,t,x) -> x^2\n",
+    "L = α1 * FirstDifferenceUpwind(grid) + α2 * SecondDifferenceCentral(grid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(Again, should do something about pprint these composite operators)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DiffEqOperatorCombination((1.0, 1.0), (UpwindOperator{ScalarField,FirstDifferenceUpwind}(ScalarField(#19, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0], [0.0, 1.01, 2.02, 3.03, 4.04, 5.05]), FirstDifferenceUpwind([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])), DiffEqOperatorComposition((SecondDifferenceCentral([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]), ScalarField(#21, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0], [0.0, 1.0, 4.0, 9.0, 16.0, 25.0])))))"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p = nothing; t = 0.0\n",
+    "update_coefficients!(L,u,p,t)\n",
+    "L"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6-element Array{Float64,1}:\n",
+       "  0.0     \n",
+       " -0.227745\n",
+       "  0.993775\n",
+       "  2.49862 \n",
+       " -9.00639 \n",
+       "  8.34501 "
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Should check this\n",
+    "L * u"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6×8 Array{Float64,2}:\n",
+       " 0.0   0.0    0.0    0.0     0.0     0.0     0.0    0.0\n",
+       " 0.0  -0.01  -0.99   1.0     0.0     0.0     0.0    0.0\n",
+       " 0.0   0.0    1.98  -5.98    4.0     0.0     0.0    0.0\n",
+       " 0.0   0.0    0.0    5.97  -14.97    9.0     0.0    0.0\n",
+       " 0.0   0.0    0.0    0.0    11.96  -27.96   16.0    0.0\n",
+       " 0.0   0.0    0.0    0.0     0.0    19.95  -44.95  25.0"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full(as_array(L))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 4. Boundary extrapolation operator $Q$\n",
     "\n",
     "Question: is it OK to shorthand \"boundary extrapolation operator\" as \"BEOperator\" or simply \"BE\"?\n",
     "\n",
@@ -321,7 +627,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1.4 Constructing operators for the Fokker-Planck equations\n",
+    "## 5. Constructing operators for the Fokker-Planck equations\n",
     "\n",
     "The most general case is in section 3.5 of the write-up:\n",
     "\n",
@@ -338,45 +644,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DiffEqOperatorComposition((AbsorbingBE(10), DiffEqOperatorCombination((1.0, 1.0, 1.0), (DiffEqOperatorComposition((DriftOperator(1.0, 10, true), DiffEqArrayOperator([0.887661 0.0 … 0.0 0.0; 0.0 0.213112 … 0.0 0.0; … ; 0.0 0.0 … 0.436606 0.0; 0.0 0.0 … 0.0 0.569388]))), DiffEqOperatorComposition((DriftOperator(1.0, 10, false), DiffEqArrayOperator([0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0; … ; 0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0]))), DiffEqOperatorComposition((DiffusionOperator(1.0, 10), DiffEqArrayOperator([1.89194 0.0 … 0.0 0.0; 0.0 0.597414 … 0.0 0.0; … ; 0.0 0.0 … 0.539805 0.0; 0.0 0.0 … 0.0 0.94818])))))))"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# The grid\n",
-    "N = 10\n",
-    "dx = 1.0\n",
-    "xs = collect(1:N) * dx # interior nodes\n",
+    "# # The grid\n",
+    "# N = 10\n",
+    "# dx = 1.0\n",
+    "# xs = collect(1:N) * dx # interior nodes\n",
     "\n",
-    "# Discretization of the differential operators\n",
-    "L1p = DriftOperator(dx, N, true)\n",
-    "L1m = DriftOperator(dx, N, false)\n",
-    "L2 = DiffusionOperator(dx, N)\n",
+    "# # Discretization of the differential operators\n",
+    "# L1p = DriftOperator(dx, N, true)\n",
+    "# L1m = DriftOperator(dx, N, false)\n",
+    "# L2 = DiffusionOperator(dx, N)\n",
     "\n",
-    "# Boundary operators\n",
-    "Q = AbsorbingBE(N)\n",
-    "# Q = Neumann_BE(N, dx, 1.0, 2.0)\n",
+    "# # Boundary operators\n",
+    "# Q = AbsorbingBE(N)\n",
+    "# # Q = Neumann_BE(N, dx, 1.0, 2.0)\n",
     "\n",
-    "# Coefficients\n",
-    "mu = rand(N)\n",
-    "mup = [mu[i] > 0.0 ? mu[i] : 0.0 for i in 1:N]\n",
-    "mum = [mu[i] < 0.0 ? mu[i] : 0.0 for i in 1:N]\n",
-    "sigma = rand(N) + 1.0\n",
+    "# # Coefficients\n",
+    "# mu = rand(N)\n",
+    "# mup = [mu[i] > 0.0 ? mu[i] : 0.0 for i in 1:N]\n",
+    "# mum = [mu[i] < 0.0 ? mu[i] : 0.0 for i in 1:N]\n",
+    "# sigma = rand(N) + 1.0\n",
     "\n",
-    "# Construct the final product\n",
-    "Ldrift = DiffEqArrayOperator(Diagonal(mup)) * L1p + DiffEqArrayOperator(Diagonal(mum)) * L1m\n",
-    "Ldiffusion = DiffEqArrayOperator(Diagonal(sigma.^2 / 2)) * L2\n",
-    "A = (Ldrift + Ldiffusion) * Q"
+    "# # Construct the final product\n",
+    "# Ldrift = DiffEqArrayOperator(Diagonal(mup)) * L1p + DiffEqArrayOperator(Diagonal(mum)) * L1m\n",
+    "# Ldiffusion = DiffEqArrayOperator(Diagonal(sigma.^2 / 2)) * L2\n",
+    "# A = (Ldrift + Ldiffusion) * Q"
    ]
   },
   {
@@ -390,33 +685,12 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "10-element Array{Float64,1}:\n",
-       " 24.4109\n",
-       " 37.4853\n",
-       " 45.6853\n",
-       " 52.2336\n",
-       " 51.9707\n",
-       " 50.2344\n",
-       " 46.5129\n",
-       " 37.9023\n",
-       " 30.9117\n",
-       " 15.7658"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Solve the HJBE (rI - A)u = x\n",
-    "r = 0.05\n",
-    "LHS = DiffEqArrayOperator(r*speye(N)) - A\n",
-    "u = LHS \\ xs"
+    "# # Solve the HJBE (rI - A)u = x\n",
+    "# r = 0.05\n",
+    "# LHS = DiffEqArrayOperator(r*speye(N)) - A\n",
+    "# u = LHS \\ xs"
    ]
   },
   {


### PR DESCRIPTION
[notebook link](https://nbviewer.jupyter.org/github/MSeeker1340/PDERoadmap/blob/function_composition/Discretizing%20Linear%20Operators.ipynb)

Main focus is to support the function composition interface suggested by @jlperla:

```julia
α1 = (u,p,t,x) -> ...
α2 = (u,p,t,x) -> ...
L = α1 * FirstDifferenceUpwind(grid) + α2 * SecondDifferenceCentral(grid)
```

Whereas for `SecondDifferenceCentral` this is more of a syntax sugar, for `FirstDifferenceUpwind` this is required. The idea is that `FirstDifferenceUpwind` itself is just a placeholder (contains relevant info such as the stencil coefficients) but by itself cannot be applied to a vector (because direction is unknown). The application of an upwind operator happens at the `*` level, which in the background is converted to an `UpwindOperator`.

`UpwindOperator` is never exposed to the user, so the user can use the function composition interface intuitively as if the central and upwind operators work the same.