### PR TITLE
Prototype for the first target (#33)

### DIFF
--- a/operator_examples/first_target.jl
+++ b/operator_examples/first_target.jl
@@ -1,0 +1,68 @@
+using LinearAlgebra, DiffEqOperators
+import DiffEqBase: AbstractDiffEqLinearOperator
+import Base: *, size, convert
+
+#############################
+# Matrix-free operators
+# The operators are defined as a subtype of AbstractDiffEqLinearOperator to make use of the composition
+# functionality. In actual code we should define a separate AbstractDerivativeOperator type hierarchy.
+# Only the most essential interface for AbstractDiffEqLinearOperator is defined: multiplication,
+# size (needed for linear combination) and conversion to AbstractMatrix (needed for linsolve).
+struct GenericDerivativeOperator{LT,QT} <: AbstractDiffEqLinearOperator{Float64}
+  L::LT
+  QB::QT
+end
+size(LB::GenericDerivativeOperator) = (size(LB.L, 1), size(LB.QB, 2))
+*(LB::GenericDerivativeOperator, x::AbstractVector{Float64}) = L.L * (L.QB * x)
+convert(::Type{AbstractMatrix}, LB::GenericDerivativeOperator) = convert(AbstractMatrix, LB.L) * convert(AbstractMatrix, LB.QB)
+
+struct UniformDiffusionStencil <: AbstractDiffEqLinearOperator{Float64}
+  M::Int
+  dx::Float64
+end
+size(L::UniformDiffusionStencil) = (L.M, L.M+2)
+*(L::UniformDiffusionStencil, x::AbstractVector{Float64}) = [x[i] + x[i+2] - 2x[i+1] for i = 1:L.M] / L.dx^2
+function convert(::Type{AbstractMatrix}, L::UniformDiffusionStencil)
+  # spdiagm/diagm always creates a square matrix so we have to construct manually.
+  # It's likely that more efficient constructions exist.
+  mat = zeros(size(L))
+  for i = 1:L.M
+    mat[i,i] = 1.0
+    mat[i,i+1] = -2.0
+    mat[i,i+2] = 1.0
+  end
+  return mat / L.dx^2
+end
+
+struct UniformDriftStencil <: AbstractDiffEqLinearOperator{Float64}
+  M::Int
+  dx::Float64
+end
+size(L::UniformDriftStencil) = (L.M, L.M+1)
+*(L::UniformDriftStencil, x::AbstractVector{Float64}) = [x[i+1] - x[i] for i = 1:L.M] / L.dx
+function convert(::Type{AbstractMatrix}, L::UniformDriftStencil)
+  mat = zeros(size(L))
+  for i = 1:L.M
+    mat[i,i] = -1.0
+    mat[i,i+1] = 1.0
+  end
+  return mat / L.dx
+end
+
+# TODO: stencil operators for irregular grids
+
+struct QRobin <: AbstractDiffEqLinearOperator{Float64}
+  M::Int
+  dx::Float64
+  al::Float64
+  bl::Float64
+  ar::Float64
+  br::Float64
+end
+size(Q::QRobin) = (Q.M+2, Q.M)
+function *(Q::QRobin, x::AbstractVector{Float64})
+  xl = x[2] + 2*Q.al*Q.dx/Q.bl * x[1]
+  xr = x[end-1] - 2*Q.ar*Q.dx/Q.br * x[end]
+  return [xl; x; xr] # could optimize using LazyArrays.jl
+end
+


### PR DESCRIPTION
Prototype code for #33. The focus is on setting up the matrix-free operators for the generic `L*QB` route and come up with a mock user interface to create the operators, all the while taking composition and irregular grid into account.

The basic idea I have is to separate the codebase into two parts: the low level operators and the high-level method `DerivativeOperator`. The user will never need to explicitly construct any of the low level operators, but instead use the interface defined by `DerivativeOperator`, which is guaranteed to return a derivative operator or a composed derivative operator (a "factory method" in OOP jargon).

The current mock `DerivativeOperator` interface looks very much the same as DiffEqOperator's current implementation, with the difference being the presence of `xgrid` serving to differentiate between uniform and irregular grids. Also I wrote a `DerivativeOperator` with no `BC` as the factory method to construct stencil operators (or we can use a different name if this is confusing).

However this version of the interface has the same issue as pointed out by https://github.com/JuliaDiffEq/PDERoadmap/issues/33#issuecomment-415056125, i.e. by packaging the construction of square derivative operators in one place we end up unable to do `LB = (L1 + L2)*QB` but only the distributed version `LB = L1*QB + L2*QB`. Of course now that we can also construct stencil operators independently, we can add another user interface for constructing `QB` (as well as utilities for extending/zero padding the Ls) and then the first version is also possible. Or we can rebuild an entirely new interface.

@jlperla I'd like to hear your opinion on the prototype. Meanwhile I'll try writing an example script to demonstrate the operators' usage.